### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Check out the [Live Demo](http://angular-dashboard-seed.flatlogic.com). Use foll
 * [Node and npm](http://nodejs.org)
 * [Bower](http://bower.io)
 * [Gulp](http://gulpjs.com)
+* [Ruby Sass] (http://sass-lang.com/install)
 
 ### Installation
 0. Clone project `git clone https://github.com/flatlogic/angular-dashboard-seed.git`


### PR DESCRIPTION
Ruby sass is a must for the gulp-ruby-sass to work. However, due to it is  a gem, there is no auto installation if you don't have it.